### PR TITLE
Add pty shell support

### DIFF
--- a/execd.go
+++ b/execd.go
@@ -341,8 +341,12 @@ func handleChannel(conn *ssh.ServerConn, newChan ssh.NewChannel, execHandler []s
 			// TODO: Handle "shell" which technically comes after "pty-req".
 			// TODO: Handle "window-change" for pty
 			// TODO: Parse payload to set initial window dimensions
-			// XXX: Obey handler
-			cmd := exec.Command("/usr/local/bin/bash")
+			var cmd *exec.Cmd
+			if *shell {
+				cmd = exec.Command(os.Getenv("SHELL"))
+			} else {
+				cmd = exec.Command(execHandler[0], execHandler[1:]...)
+			}
 			if !*env {
 				cmd.Env = []string{}
 			}

--- a/pty.go
+++ b/pty.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"encoding/binary"
+	"syscall"
+	"unsafe"
+)
+
+//// winsize is borrowed from https://github.com/creack/termios/blob/master/win/win.go
+
+// winsize stores the Heighty and Width of a terminal.
+type winsize struct {
+	Height uint16
+	Width  uint16
+	x      uint16 // unused
+	y      uint16 // unused
+}
+
+func setWinsize(fd uintptr, width int, height int) {
+	ws := &winsize{Width: uint16(width), Height: uint16(height)}
+	syscall.Syscall(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCSWINSZ), uintptr(unsafe.Pointer(ws)))
+}
+
+//// Helpers below are borrowed from go.crypto circa 2011:
+
+// parsePtyRequest parses the payload of the pty-req message and extracts the
+// dimensions of the terminal. See RFC 4254, section 6.2.
+func parsePtyRequest(s []byte) (width, height int, ok bool) {
+	_, s, ok = parseString(s)
+	if !ok {
+		return
+	}
+	width32, s, ok := parseUint32(s)
+	if !ok {
+		return
+	}
+	height32, _, ok := parseUint32(s)
+	width = int(width32)
+	height = int(height32)
+	if width < 1 {
+		ok = false
+	}
+	if height < 1 {
+		ok = false
+	}
+	return
+}
+
+func parseWinchRequest(s []byte) (width, height int, ok bool) {
+	width32, s, ok := parseUint32(s)
+	if !ok {
+		return
+	}
+	height32, s, ok := parseUint32(s)
+	if !ok {
+		return
+	}
+
+	width = int(width32)
+	height = int(height32)
+	if width < 1 {
+		ok = false
+	}
+	if height < 1 {
+		ok = false
+	}
+	return
+}
+
+func parseString(in []byte) (out string, rest []byte, ok bool) {
+	if len(in) < 4 {
+		return
+	}
+	length := binary.BigEndian.Uint32(in)
+	if uint32(len(in)) < 4+length {
+		return
+	}
+	out = string(in[4 : 4+length])
+	rest = in[4+length:]
+	ok = true
+	return
+}
+
+func parseUint32(in []byte) (uint32, []byte, bool) {
+	if len(in) < 4 {
+		return 0, nil, false
+	}
+	return binary.BigEndian.Uint32(in), in[4:], true
+}


### PR DESCRIPTION
**Status**: Should be functional, though messy.
- [x] Lots of TODO's/FIXME's that need consideration/answering (extra eyes/opinions appreciated here)
- [x] Handler/shell is hardcoded to bash at the moment for no good reason, unhardcode it. (XXX'd)
- [x] After the client exits the shell, need to send an extra char for the connection to terminate. I suspect that's because we're defer-closing only until after the process's .Wait() is done. Probably need to close earlier?
- [ ] The req-type switch loop is enormous, need to refactor that out. It was originally single-path, but now it's a stateful req/response thing so it'll need a new shape.
- [x] Need to wire up handlers for col/row size data.

Fixes #2
