### PR TITLE
Unmarshal the payload of a request.

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -107,7 +107,9 @@ func (h *sshHandler) handleExec(req *ssh.Request) {
 	h.Lock()
 	defer h.Unlock()
 
-	cmdline := string(req.Payload[4:])
+	var payload = struct{ Value string }{}
+	ssh.Unmarshal(req.Payload, &payload)
+	cmdline := payload.Value
 
 	// Initialize Cmd
 	var cmd *exec.Cmd


### PR DESCRIPTION
This unmarshals the payload of a request instead of trimming the length field and then reading the remainder of the request.
