### PR TITLE
fix invalid keylength issue

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -76,7 +76,7 @@ func setupHostKey(config *ssh.ServerConfig) {
 		}
 	} else {
 		debug("no host key provided, generating host key")
-		key, err := rsa.GenerateKey(rand.Reader, 768)
+		key, err := rsa.GenerateKey(rand.Reader, 1024)
 		if err != nil {
 			log.Fatalln("failed key generate:", err)
 		}


### PR DESCRIPTION
Old clients (OpenSSH_7.4 and before) are working fine, but recent openssh clients are rejecting the connection to sshfront with: ` Invalid key length` error message.
